### PR TITLE
refactor: removing pagerduty sync to limitation in Backstage

### DIFF
--- a/src/processor/PagerDutyEntityProcessor.ts
+++ b/src/processor/PagerDutyEntityProcessor.ts
@@ -197,7 +197,7 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
                                 // set on the entity configuration file
                                 // !!!
 
-                                // entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit, true);
+                                // entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
 
                                 break;
                             case "both":
@@ -229,7 +229,7 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
     }
 }
 
-export function refreshServiceDependencyAnnotations(entity: Entity, mappingsDic: Record<string, string>, dependencies: string[], emit: CatalogProcessorEmit, replace = false): string[] {
+export function refreshServiceDependencyAnnotations(entity: Entity, mappingsDic: Record<string, string>, dependencies: string[], emit: CatalogProcessorEmit): string[] {
     const dependencyList: string[] = [];
     dependencies.forEach((dependencyId) => {
         const foundEntityRef = mappingsDic[dependencyId];


### PR DESCRIPTION
### Description

This PR removes the logic of syncing from PagerDuty to Backstage. Due to a limitation on how entity relations are emitted in `CatalogProcessor` the relations existing on file cannot be removed from the entity. This adds some limits on the capacity to fully overwrite relations for an entity and therefore making impossible a full-sync from PagerDuty to Backstage to work. 

Once/If the design limitation changes, this capability will be introduced once again.

**Issue number:** N/A

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
