### PR TITLE
feat: enable pagerduty service dependency sync

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -102,12 +102,16 @@ export class PagerDutyClient {
                 throw new Error(`Failed to remove service relation from service ${serviceId}. PagerDuty API returned a server error. Retrying with the same arguments will not work.`);
             }
 
+            if (response.status === 404) {
+                throw new Error(`Service ${serviceId} or dependencies not found.`);
+            }
+
             if (!response.ok) {
                 throw new Error(await response.text());
             }
         } catch (error) {
-            this.logger.error(`Failed to remove dependencies: ${error}`);
-            throw new Error(`Failed to remove dependencies: ${error}`);
+            this.logger.error(`Failed to remove dependencies from ${serviceId}: ${error}`);
+            throw new Error(`Failed to remove dependencies from ${serviceId}: ${error}`);
         }
     }
 

--- a/src/processor/PagerDutyEntityProcessor.ts
+++ b/src/processor/PagerDutyEntityProcessor.ts
@@ -36,6 +36,21 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
         return "PagerDutyEntityProcessor";
     }
 
+    async preProcessEntity(entity: Entity): Promise<Entity> {
+        if (this.shouldProcessEntity(entity)) {
+            const strategySetting = await client.getServiceDependencyStrategySetting();
+
+            if (strategySetting && strategySetting === "pagerduty") {
+                if (entity.spec?.dependsOn){
+                    // empty the dependsOn array
+                    entity.spec.dependsOn = [];
+                }
+            }
+        }
+
+        return entity;
+    }
+
     async postProcessEntity(entity: Entity, _location: LocationSpec, emit: CatalogProcessorEmit): Promise<Entity> {
         if (this.shouldProcessEntity(entity)) {
             try {
@@ -197,7 +212,7 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
                                 // set on the entity configuration file
                                 // !!!
 
-                                // entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
+                                entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
 
                                 break;
                             case "both":


### PR DESCRIPTION
### Description

Release [0.3.0](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.0) had a limitation that prevented users from enabling PagerDuty as their main source for syncing service dependencies. 

With the help of the Backstage team, we were able to implement a few changes that overcome this limitation. With this PR, users can now set PagerDuty as their main source for service dependencies.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
