### PR TITLE
release: 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "types": "dist/index.d.ts"
   },
   "backstage": {
-    "role": "backend-plugin-module"
+    "role": "backend-plugin-module",
+    "pluginId": "catalog",
+    "pluginPackage": "pagerduty-entity-processor"
   },
   "homepage": "https://pagerduty.github.io/backstage-plugin-docs/index.html",
   "repository": {

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -102,12 +102,16 @@ export class PagerDutyClient {
                 throw new Error(`Failed to remove service relation from service ${serviceId}. PagerDuty API returned a server error. Retrying with the same arguments will not work.`);
             }
 
+            if (response.status === 404) {
+                throw new Error(`Service ${serviceId} or dependencies not found.`);
+            }
+
             if (!response.ok) {
                 throw new Error(await response.text());
             }
         } catch (error) {
-            this.logger.error(`Failed to remove dependencies: ${error}`);
-            throw new Error(`Failed to remove dependencies: ${error}`);
+            this.logger.error(`Failed to remove dependencies from ${serviceId}: ${error}`);
+            throw new Error(`Failed to remove dependencies from ${serviceId}: ${error}`);
         }
     }
 

--- a/src/processor/PagerDutyEntityProcessor.ts
+++ b/src/processor/PagerDutyEntityProcessor.ts
@@ -1,6 +1,6 @@
 import { DiscoveryService, LoggerService } from "@backstage/backend-plugin-api";
-import { Entity } from "@backstage/catalog-model";
-import { CatalogProcessor, CatalogProcessorEmit } from "@backstage/plugin-catalog-node";
+import { Entity, RELATION_DEPENDS_ON, RELATION_DEPENDENCY_OF } from "@backstage/catalog-model";
+import { CatalogProcessor, CatalogProcessorEmit, processingResult } from "@backstage/plugin-catalog-node";
 import { LocationSpec } from "@backstage/plugin-catalog-common";
 import { PagerDutyClient } from "../apis/client";
 
@@ -190,9 +190,14 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
                                 break;
                             case "pagerduty":
                                 // Update dependencies on Backstage with dependenciesMissingInBackstage
-                                this.logger.debug(`Updating dependencies on Backstage with: ${JSON.stringify(dependenciesMissingInBackstage)}`);
+                                
+                                // !!!
+                                // This is not supported yet due to a limitation on Backstage side
+                                // that prevents a full override of the dependencies once they are
+                                // set on the entity configuration file
+                                // !!!
 
-                                entity.spec!.dependsOn = addServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
+                                // entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
 
                                 break;
                             case "both":
@@ -205,11 +210,11 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
                                 }
 
                                 // Add missing dependencies to Backstage
-                                entity.spec!.dependsOn = addServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
+                                entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
 
                                 break;
                             default:
-                                // Do nothing. Stragety not defined or set to disabled
+                                // Do nothing. Strategy not defined or set to disabled
                                 break;
                         }
                     }
@@ -224,12 +229,12 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
     }
 }
 
-export function addServiceDependencyAnnotations(entity: Entity, mappingsDic: Record<string, string>, dependencies: string[], emit: CatalogProcessorEmit): string[] {
+export function refreshServiceDependencyAnnotations(entity: Entity, mappingsDic: Record<string, string>, dependencies: string[], emit: CatalogProcessorEmit): string[] {
     const dependencyList: string[] = [];
     dependencies.forEach((dependencyId) => {
         const foundEntityRef = mappingsDic[dependencyId];
 
-        if (foundEntityRef) {
+        if (foundEntityRef && foundEntityRef !== "") {
             dependencyList.push(foundEntityRef);
 
             const entityRefParts = foundEntityRef.split(":");
@@ -238,39 +243,33 @@ export function addServiceDependencyAnnotations(entity: Entity, mappingsDic: Rec
             const namespace = namespaceName[0];
             const name = namespaceName[1];
 
-            emit({
-                relation: {
-                    source: {
-                        kind: entity.kind,
-                        namespace: entity.metadata.namespace!,
-                        name: entity.metadata.name,
-                    },
-                    target: {
-                        kind: kind,
-                        namespace: namespace,
-                        name: name,
-                    },
-                    type: "dependsOn",
+            emit(processingResult.relation({
+                source: {
+                    kind: entity.kind,
+                    namespace: entity.metadata.namespace!,
+                    name: entity.metadata.name,
                 },
-                type: "relation"
-            });
-
-            emit({
-                relation: {
-                    source: {
-                        kind: kind,
-                        namespace: namespace,
-                        name: name,
-                    },
-                    target: {
-                        kind: entity.kind,
-                        namespace: entity.metadata.namespace!,
-                        name: entity.metadata.name,
-                    },
-                    type: "dependencyOf",
+                target: {
+                    kind: kind,
+                    namespace: namespace,
+                    name: name,
                 },
-                type: "relation"
-            });
+                type: RELATION_DEPENDS_ON,
+            }));
+            
+            emit(processingResult.relation({
+                source: {
+                    kind: kind,
+                    namespace: namespace,
+                    name: name,
+                },
+                target: {
+                    kind: entity.kind,
+                    namespace: entity.metadata.namespace!,
+                    name: entity.metadata.name,
+                },
+                type: RELATION_DEPENDENCY_OF,
+            }));
         }
     });
 

--- a/src/processor/PagerDutyEntityProcessor.ts
+++ b/src/processor/PagerDutyEntityProcessor.ts
@@ -36,6 +36,21 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
         return "PagerDutyEntityProcessor";
     }
 
+    async preProcessEntity(entity: Entity): Promise<Entity> {
+        if (this.shouldProcessEntity(entity)) {
+            const strategySetting = await client.getServiceDependencyStrategySetting();
+
+            if (strategySetting && strategySetting === "pagerduty") {
+                if (entity.spec?.dependsOn){
+                    // empty the dependsOn array
+                    entity.spec.dependsOn = [];
+                }
+            }
+        }
+
+        return entity;
+    }
+
     async postProcessEntity(entity: Entity, _location: LocationSpec, emit: CatalogProcessorEmit): Promise<Entity> {
         if (this.shouldProcessEntity(entity)) {
             try {
@@ -197,7 +212,7 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
                                 // set on the entity configuration file
                                 // !!!
 
-                                // entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
+                                entity.spec!.dependsOn = refreshServiceDependencyAnnotations(entity, mappings, dependencyIds, emit);
 
                                 break;
                             case "both":


### PR DESCRIPTION
### Description

Release [0.3.0](https://github.com/PagerDuty/backstage-plugin-entity-processor/releases/tag/0.3.0) had a limitation that prevented users from enabling PagerDuty as their main source for syncing service dependencies.

With the help of the Backstage team, we were able to implement a few changes that overcome this limitation. With this release, users can now set PagerDuty as their main source for service dependencies and get their dependencies sync to Backstage for all mapped entities.

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
